### PR TITLE
Prepare python-v1.32.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 ## [python-v1.32.0]
 
 ### Released 2025-06-06
+
 ### Changed
+
 - Update collector and instrumentation to latest upstream version
 
 [python-v1.32.0]: https://github.com/SumoLogic/sumologic-otel-lambda/releases/tag/python-v1.32.0
-
 
 ## [nodejs-v1.17.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [python-v1.32.0]
+
+### Released 2025-06-06
+### Changed
+- Update collector and instrumentation to latest upstream version
+
+[python-v1.32.0]: https://github.com/SumoLogic/sumologic-otel-lambda/releases/tag/python-v1.32.0
+
+
 ## [nodejs-v1.17.2]
 
 ### Released 2024-07-24

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Released `sumologic-otel-lambda` layers are available:
 
 - NodeJS layer contains OpenTelemetry JavaScript SDK `v1.17.1` and OpenTelemetry Collector `v0.`87.0. Please see list of [lambda layers](https://github.com/SumoLogic/sumologic-otel-lambda/blob/release-nodejs-v1.17.2/nodejs/README.md).
 
-- Python layer contains OpenTelemetry Python SDK `v1.20.0` with instrumentation `v0.41b0` and OpenTelemetry Collector `v0.87.0`. Please see list of [lambda layers](https://github.com/SumoLogic/sumologic-otel-lambda/blob/release-python-v1.20.0/python/README.md).
+- Python layer contains OpenTelemetry Python SDK `v1.32.0` with instrumentation `v0.53b0` and OpenTelemetry Collector `v0.123.0`. Please see list of [lambda layers](https://github.com/SumoLogic/sumologic-otel-lambda/blob/release-python-v1.32.0/python/README.md).
 
 ## Sample applications
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,11 +1,13 @@
 # Releasing guide
 
-Perform the following steps in order to release new verions of helm chart.
+Perform the following steps in order to release new versions:
 
 1. Prepare and merge PR with following changes:
 
     - update [changelog](../CHANGELOG.md)
     - in [README.md](../README.md) update version of the latest lambda layers
+    - update `<language>/layer-data.sh`
+    - update `<language>/sample-apps/template.yaml`
 
 1. Create and push new tag:
 

--- a/python/README.md
+++ b/python/README.md
@@ -2,55 +2,55 @@
 
 Sumo Logic lambda layers support:
 
-- `Python` in versions `3.7, 3.8, 3.9` and `3.10` runtimes (note that `Python 3.7` AWS runtime doesn't support `arm64` architecture)
+- `Python` in versions `3.9, 3.10, 3.11, 3.12` and `3.13` runtimes
 - `x86_64` and `arm64` architectures
 
 ## AMD64 Lambda Layers List
 
 | Region         | ARN                                                                                            |
 |----------------|------------------------------------------------------------------------------------------------|
-| af-south-1     | arn:aws:lambda:af-south-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1     |
-| ap-east-1      | arn:aws:lambda:ap-east-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1      |
-| ap-northeast-1 | arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1 |
-| ap-northeast-2 | arn:aws:lambda:ap-northeast-2:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1 |
-| ap-northeast-3 | arn:aws:lambda:ap-northeast-3:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1 |
-| ap-south-1     | arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1     |
-| ap-southeast-1 | arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1 |
-| ap-southeast-2 | arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1 |
-| ca-central-1   | arn:aws:lambda:ca-central-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1   |
-| eu-central-1   | arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1   |
-| eu-north-1     | arn:aws:lambda:eu-north-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1     |
-| eu-south-1     | arn:aws:lambda:eu-south-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1     |
-| eu-west-1      | arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1      |
-| eu-west-2      | arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1      |
-| eu-west-3      | arn:aws:lambda:eu-west-3:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1      |
-| me-south-1     | arn:aws:lambda:me-south-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1     |
-| sa-east-1      | arn:aws:lambda:sa-east-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1      |
-| us-east-1      | arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1      |
-| us-east-2      | arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1      |
-| us-west-1      | arn:aws:lambda:us-west-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1      |
-| us-west-2      | arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-20-0:1      |
+| af-south-1     | arn:aws:lambda:af-south-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1     |
+| ap-east-1      | arn:aws:lambda:ap-east-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1      |
+| ap-northeast-1 | arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1 |
+| ap-northeast-2 | arn:aws:lambda:ap-northeast-2:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1 |
+| ap-northeast-3 | arn:aws:lambda:ap-northeast-3:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1 |
+| ap-south-1     | arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1     |
+| ap-southeast-1 | arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1 |
+| ap-southeast-2 | arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1 |
+| ca-central-1   | arn:aws:lambda:ca-central-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1   |
+| eu-central-1   | arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1   |
+| eu-north-1     | arn:aws:lambda:eu-north-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1     |
+| eu-south-1     | arn:aws:lambda:eu-south-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1     |
+| eu-west-1      | arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1      |
+| eu-west-2      | arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1      |
+| eu-west-3      | arn:aws:lambda:eu-west-3:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1      |
+| me-south-1     | arn:aws:lambda:me-south-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1     |
+| sa-east-1      | arn:aws:lambda:sa-east-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1      |
+| us-east-1      | arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1      |
+| us-east-2      | arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1      |
+| us-west-1      | arn:aws:lambda:us-west-1:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1      |
+| us-west-2      | arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-lambda-python-x86_64-v1-32-0:1      |
 
 ## ARM64 Lambda Layers List
 
 | Region         | ARN                                                                                           |
 |----------------|-----------------------------------------------------------------------------------------------|
-| ap-northeast-1 | arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-20-0:1 |
-| ap-northeast-3 | arn:aws:lambda:ap-northeast-3:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-20-0:1 |
-| ap-south-1     | arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-20-0:1     |
-| ap-southeast-1 | arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-20-0:1 |
-| ap-southeast-2 | arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-20-0:1 |
-| eu-central-1   | arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-20-0:1   |
-| eu-west-1      | arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-20-0:1      |
-| eu-west-2      | arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-20-0:1      |
-| us-east-1      | arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-20-0:1      |
-| us-east-2      | arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-20-0:1      |
-| us-west-2      | arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-20-0:1      |
+| ap-northeast-1 | arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-32-0:1 |
+| ap-northeast-3 | arn:aws:lambda:ap-northeast-3:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-32-0:1 |
+| ap-south-1     | arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-32-0:1     |
+| ap-southeast-1 | arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-32-0:1 |
+| ap-southeast-2 | arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-32-0:1 |
+| eu-central-1   | arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-32-0:1   |
+| eu-west-1      | arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-32-0:1      |
+| eu-west-2      | arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-32-0:1      |
+| us-east-1      | arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-32-0:1      |
+| us-east-2      | arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-32-0:1      |
+| us-west-2      | arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-lambda-python-arm64-v1-32-0:1      |
 
 ## Lambda Container dependencies
 
-- [amd64 containers](https://github.com/SumoLogic/sumologic-otel-lambda/releases/download/python-v1.20.0/opentelemetry-python-amd64.zip)
-- [arm64 containers](https://github.com/SumoLogic/sumologic-otel-lambda/releases/download/python-v1.20.0/opentelemetry-python-arm64.zip)
+- [amd64 containers](https://github.com/SumoLogic/sumologic-otel-lambda/releases/download/python-v1.32.0/opentelemetry-python-amd64.zip)
+- [arm64 containers](https://github.com/SumoLogic/sumologic-otel-lambda/releases/download/python-v1.32.0/opentelemetry-python-arm64.zip)
 
 ## Sample applications
 

--- a/python/layer-data.sh
+++ b/python/layer-data.sh
@@ -3,7 +3,7 @@
 OFFICIAL_LAYER_NAME=sumologic-otel-lambda-python
 ARCHITECTURE_AMD=x86_64
 ARCHITECTURE_ARM=arm64
-RUNTIMES='python3.7 python3.8 python3.9 python3.10 python3.11'
-DESCRIPTION='Sumo Logic OTel Collector and Python Lambda Layer https://github.com/SumoLogic/sumologic-otel-lambda/tree/main/python'
+RUNTIMES='python3.9 python3.10 python3.11 python3.12 python3.13'
+DESCRIPTION='Sumo Logic OTEL Collector and Python Lambda Layer https://github.com/SumoLogic/sumologic-otel-lambda/tree/release-python-v1.32.0/python'
 LICENSE=Apache-2.0
-VERSION=v1-20-0
+VERSION=v1-32-0

--- a/python/sample-apps/template.yaml
+++ b/python/sample-apps/template.yaml
@@ -49,34 +49,34 @@ Outputs:
 Mappings:
   RegionMap:
     ap-northeast-1:
-      layer: "arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     ap-northeast-2:
-      layer: "arn:aws:lambda:ap-northeast-2:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:ap-northeast-2:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     ap-south-1:
-      layer: "arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     ap-southeast-1:
-      layer: "arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     ap-southeast-2:
-      layer: "arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     ca-central-1:
-      layer: "arn:aws:lambda:ca-central-1:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:ca-central-1:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     eu-central-1:
-      layer: "arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     eu-north-1:
-      layer: "arn:aws:lambda:eu-north-1:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:eu-north-1:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     eu-west-1:
-      layer: "arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     eu-west-2:
-      layer: "arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     eu-west-3:
-      layer: "arn:aws:lambda:eu-west-3:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:eu-west-3:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     sa-east-1:
-      layer: "arn:aws:lambda:sa-east-1:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:sa-east-1:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     us-east-1:
-      layer: "arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     us-east-2:
-      layer: "arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     us-west-1:
-      layer: "arn:aws:lambda:us-west-1:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:us-west-1:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"
     us-west-2:
-      layer: "arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-python-x86_64-v1-20-0:1"
+      layer: "arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-python-x86_64-v1-32-0:1"


### PR DESCRIPTION
Preparations for releasing `python-v1.32.0`.

Note that it is expected for `markdown-link-check` to be failing here, because the release process documentation makes you update links that only become live later in the process...

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
