### PR TITLE
Fix ARN artifacts uploading/downloading

### DIFF
--- a/.github/workflows/publish-release-layer.yml
+++ b/.github/workflows/publish-release-layer.yml
@@ -104,7 +104,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}-${{ env.LANGUAGE }}-${{ matrix.architecture }}-layer-arns-artifact
+          name: ${{ env.ARTIFACT_NAME }}-${{ env.LANGUAGE }}-${{ matrix.architecture }}-layer-arns-artifact-${{ matrix.aws_region }}
           path: layer-arn-${{ matrix.architecture }}-${{ matrix.aws_region }}
       - name: Clean s3
         if: always()

--- a/.github/workflows/release-build-java.yml
+++ b/.github/workflows/release-build-java.yml
@@ -74,7 +74,7 @@ jobs:
           echo "AMD64_LAYERS<<EOF" >> "$GITHUB_ENV"
           cat amd64layerslist.md >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
-      - name: Create amd64 layers table
+      - name: Create arm64 layers table
         id: arm64layerslist
         run: |
           echo "### ARM64 Lambda Layers List" > arm64layerslist.md

--- a/.github/workflows/release-build-java.yml
+++ b/.github/workflows/release-build-java.yml
@@ -48,12 +48,14 @@ jobs:
       - name: Download amd64 Layer ARNs
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.ref_name }}-java-amd64-layer-arns-artifact
+          pattern: ${{ github.ref_name }}-java-amd64-layer-arns-artifact-*
+          merge-multiple: true
           path: amd64layerarns/
       - name: Download arm64 Layer ARNs
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.ref_name }}-java-arm64-layer-arns-artifact
+          pattern: ${{ github.ref_name }}-java-arm64-layer-arns-artifact-*
+          merge-multiple: true
           path: arm64layerarns/
       - uses: actions/setup-node@v4
       - name: Install markdown-table-formatter

--- a/.github/workflows/release-build-nodejs.yml
+++ b/.github/workflows/release-build-nodejs.yml
@@ -74,7 +74,7 @@ jobs:
           echo "AMD64_LAYERS<<EOF" >> "$GITHUB_ENV"
           cat amd64layerslist.md >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
-      - name: Create amd64 layers table
+      - name: Create arm64 layers table
         id: arm64layerslist
         run: |
           echo "### ARM64 Lambda Layers List" > arm64layerslist.md

--- a/.github/workflows/release-build-nodejs.yml
+++ b/.github/workflows/release-build-nodejs.yml
@@ -48,12 +48,14 @@ jobs:
       - name: Download amd64 Layer ARNs
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.ref_name }}-nodejs-amd64-layer-arns-artifact
+          pattern: ${{ github.ref_name }}-nodejs-amd64-layer-arns-artifact-*
+          merge-multiple: true
           path: amd64layerarns/
       - name: Download arm64 Layer ARNs
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.ref_name }}-nodejs-arm64-layer-arns-artifact
+          pattern: ${{ github.ref_name }}-nodejs-arm64-layer-arns-artifact-*
+          merge-multiple: true
           path: arm64layerarns/
       - uses: actions/setup-node@v4
       - name: Install markdown-table-formatter

--- a/.github/workflows/release-build-python.yml
+++ b/.github/workflows/release-build-python.yml
@@ -48,12 +48,14 @@ jobs:
       - name: Download amd64 Layer ARNs
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.ref_name }}-python-amd64-layer-arns-artifact
+          pattern: ${{ github.ref_name }}-python-amd64-layer-arns-artifact-*
+          merge-multiple: true
           path: amd64layerarns/
       - name: Download arm64 Layer ARNs
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.ref_name }}-python-arm64-layer-arns-artifact
+          pattern: ${{ github.ref_name }}-python-arm64-layer-arns-artifact-*
+          merge-multiple: true
           path: arm64layerarns/
       - uses: actions/setup-node@v4
       - name: Install markdown-table-formatter
@@ -72,7 +74,7 @@ jobs:
           echo "AMD64_LAYERS<<EOF" >> "$GITHUB_ENV"
           cat amd64layerslist.md >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
-      - name: Create amd64 layers table
+      - name: Create arm64 layers table
         id: arm64layerslist
         run: |
           echo "### ARM64 Lambda Layers List" > arm64layerslist.md


### PR DESCRIPTION
**Description:**

With the upgrade of `{download,upload}-artifact` from `v3` to `v4`, the way the release workflows gather and use the various lambda layer ARNs broke.

This changes the release workflows so that:
- each layer ARN is uploaded to a separate artifact
- those separate artifacts are downloaded and extracted together so that the rest of the pipeline works without further changes

See:
- https://github.com/actions/upload-artifact/blob/v4.6.2/README.md#not-uploading-to-the-same-artifact
- https://github.com/actions/download-artifact/blob/v4.3.0/README.md#download-multiple-filtered-artifacts-to-the-same-directory

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
