### PR TITLE
Prepare java-v2.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [java-v2.15.0]
+
+### Released 2025-06-09
+
+### Changed
+
+- Update collector and instrumentation to latest upstream version
+
+[java-v2.15.0]: https://github.com/SumoLogic/sumologic-otel-lambda/releases/tag/java-v2.15.0
+
 ## [python-v1.32.0]
 
 ### Released 2025-06-06

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `sumologic-otel-lambda` publishes preconfigured [OpenTelemetry Lambda](https://github.com/open-telemetry/opentelemetry-lambda) layers which provide instrumentation for AWS Lambda functions.
 Released `sumologic-otel-lambda` layers are available:
 
-- Java wrapper layer contains OpenTelemetry Java `v1.30.1` and OpenTelemetry Collector `v0.87.0`. Please see list of [lambda layers](https://github.com/SumoLogic/sumologic-otel-lambda/blob/release-java-v1.30.1/java/README.md).
+- Java wrapper layer contains OpenTelemetry Java `v2.15.0` and OpenTelemetry Collector `v0.123.0`. Please see list of [lambda layers](https://github.com/SumoLogic/sumologic-otel-lambda/blob/release-java-v2.15.0/java/README.md).
 
 - NodeJS layer contains OpenTelemetry JavaScript SDK `v1.17.1` and OpenTelemetry Collector `v0.`87.0. Please see list of [lambda layers](https://github.com/SumoLogic/sumologic-otel-lambda/blob/release-nodejs-v1.17.2/nodejs/README.md).
 

--- a/java/README.md
+++ b/java/README.md
@@ -4,55 +4,55 @@ Layers for running Java applications on AWS Lambda with OpenTelemetry.
 
 Sumo Logic lambda layers support:
 
-- `Java8 (Corretto)` and `Java11 (Corretto)` runtimes
+- `Java8`, `Java11`, `Java17` and `Java21` runtimes
 - `x86_64` and `arm64` architectures
 
 ## AMD64 Lambda Layers List
 
 | Region         | ARN                                                                                          |
 |----------------|----------------------------------------------------------------------------------------------|
-| af-south-1     | arn:aws:lambda:af-south-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2     |
-| ap-east-1      | arn:aws:lambda:ap-east-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2      |
-| ap-northeast-1 | arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2 |
-| ap-northeast-2 | arn:aws:lambda:ap-northeast-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2 |
-| ap-northeast-3 | arn:aws:lambda:ap-northeast-3:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2 |
-| ap-south-1     | arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2     |
-| ap-southeast-1 | arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2 |
-| ap-southeast-2 | arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2 |
-| ca-central-1   | arn:aws:lambda:ca-central-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2   |
-| eu-central-1   | arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2   |
-| eu-north-1     | arn:aws:lambda:eu-north-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2     |
-| eu-south-1     | arn:aws:lambda:eu-south-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2     |
-| eu-west-1      | arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2      |
-| eu-west-2      | arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2      |
-| eu-west-3      | arn:aws:lambda:eu-west-3:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2      |
-| me-south-1     | arn:aws:lambda:me-south-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2     |
-| sa-east-1      | arn:aws:lambda:sa-east-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2      |
-| us-east-1      | arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2      |
-| us-east-2      | arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2      |
-| us-west-1      | arn:aws:lambda:us-west-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2      |
-| us-west-2      | arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2      |
+| af-south-1     | arn:aws:lambda:af-south-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1     |
+| ap-east-1      | arn:aws:lambda:ap-east-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1      |
+| ap-northeast-1 | arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1 |
+| ap-northeast-2 | arn:aws:lambda:ap-northeast-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1 |
+| ap-northeast-3 | arn:aws:lambda:ap-northeast-3:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1 |
+| ap-south-1     | arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1     |
+| ap-southeast-1 | arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1 |
+| ap-southeast-2 | arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1 |
+| ca-central-1   | arn:aws:lambda:ca-central-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1   |
+| eu-central-1   | arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1   |
+| eu-north-1     | arn:aws:lambda:eu-north-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1     |
+| eu-south-1     | arn:aws:lambda:eu-south-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1     |
+| eu-west-1      | arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1      |
+| eu-west-2      | arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1      |
+| eu-west-3      | arn:aws:lambda:eu-west-3:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1      |
+| me-south-1     | arn:aws:lambda:me-south-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1     |
+| sa-east-1      | arn:aws:lambda:sa-east-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1      |
+| us-east-1      | arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1      |
+| us-east-2      | arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1      |
+| us-west-1      | arn:aws:lambda:us-west-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1      |
+| us-west-2      | arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1      |
 
 ## ARM64 Lambda Layers List
 
 | Region         | ARN                                                                                         |
 |----------------|---------------------------------------------------------------------------------------------|
-| ap-northeast-1 | arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v1-30-1:2 |
-| ap-northeast-3 | arn:aws:lambda:ap-northeast-3:663229565520:layer:sumologic-otel-lambda-java-arm64-v1-30-1:2 |
-| ap-south-1     | arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v1-30-1:2     |
-| ap-southeast-1 | arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v1-30-1:2 |
-| ap-southeast-2 | arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-lambda-java-arm64-v1-30-1:2 |
-| eu-central-1   | arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v1-30-1:2   |
-| eu-west-1      | arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v1-30-1:2      |
-| eu-west-2      | arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-lambda-java-arm64-v1-30-1:2      |
-| us-east-1      | arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v1-30-1:2      |
-| us-east-2      | arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-lambda-java-arm64-v1-30-1:2      |
-| us-west-2      | arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-lambda-java-arm64-v1-30-1:2      |
+| ap-northeast-1 | arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v2-15-0:1 |
+| ap-northeast-3 | arn:aws:lambda:ap-northeast-3:663229565520:layer:sumologic-otel-lambda-java-arm64-v2-15-0:1 |
+| ap-south-1     | arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v2-15-0:1     |
+| ap-southeast-1 | arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v2-15-0:1 |
+| ap-southeast-2 | arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-lambda-java-arm64-v2-15-0:1 |
+| eu-central-1   | arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v2-15-0:1   |
+| eu-west-1      | arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v2-15-0:1      |
+| eu-west-2      | arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-lambda-java-arm64-v2-15-0:1      |
+| us-east-1      | arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-lambda-java-arm64-v2-15-0:1      |
+| us-east-2      | arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-lambda-java-arm64-v2-15-0:1      |
+| us-west-2      | arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-lambda-java-arm64-v2-15-0:1      |
 
 ## Lambda Container dependencies
 
-- [amd64 containers](https://github.com/SumoLogic/sumologic-otel-lambda/releases/download/java-v1.30.1/opentelemetry-java-wrapper-amd64.zip)
-- [arm64 containers](https://github.com/SumoLogic/sumologic-otel-lambda/releases/download/java-v1.30.1/opentelemetry-java-wrapper-arm64.zip)
+- [amd64 containers](https://github.com/SumoLogic/sumologic-otel-lambda/releases/download/java-v2.15.0/opentelemetry-java-wrapper-amd64.zip)
+- [arm64 containers](https://github.com/SumoLogic/sumologic-otel-lambda/releases/download/java-v2.15.0/opentelemetry-java-wrapper-arm64.zip)
 
 ## Sample applications
 

--- a/java/layer-data.sh
+++ b/java/layer-data.sh
@@ -3,7 +3,7 @@
 OFFICIAL_LAYER_NAME=sumologic-otel-lambda-java
 ARCHITECTURE_AMD=x86_64
 ARCHITECTURE_ARM=arm64
-RUNTIMES='java11 java8.al2'
-DESCRIPTION='Sumo Logic OTel Collector and Java Lambda Layer https://github.com/SumoLogic/sumologic-otel-lambda/tree/main/java'
+RUNTIMES='java8.al2 java11 java17 java21'
+DESCRIPTION='Sumo Logic OTEL Collector and Java Lambda Layer https://github.com/SumoLogic/sumologic-otel-lambda/tree/release-java-2.15.0/java'
 LICENSE=Apache-2.0
-VERSION=v1-30-1
+VERSION=v2-15-0

--- a/java/sample-apps/template.yaml
+++ b/java/sample-apps/template.yaml
@@ -49,34 +49,34 @@ Outputs:
 Mappings:
   RegionMap:
     ap-northeast-1:
-      layer: "arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:ap-northeast-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     ap-northeast-2:
-      layer: "arn:aws:lambda:ap-northeast-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:ap-northeast-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     ap-south-1:
-      layer: "arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:ap-south-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     ap-southeast-1:
-      layer: "arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:ap-southeast-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     ap-southeast-2:
-      layer: "arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:ap-southeast-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     ca-central-1:
-      layer: "arn:aws:lambda:ca-central-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:ca-central-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     eu-central-1:
-      layer: "arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:eu-central-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     eu-north-1:
-      layer: "arn:aws:lambda:eu-north-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:eu-north-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     eu-west-1:
-      layer: "arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:eu-west-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     eu-west-2:
-      layer: "arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:eu-west-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     eu-west-3:
-      layer: "arn:aws:lambda:eu-west-3:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:eu-west-3:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     sa-east-1:
-      layer: "arn:aws:lambda:sa-east-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:sa-east-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     us-east-1:
-      layer: "arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:us-east-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     us-east-2:
-      layer: "arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:us-east-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     us-west-1:
-      layer: "arn:aws:lambda:us-west-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:us-west-1:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"
     us-west-2:
-      layer: "arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v1-30-1:2"
+      layer: "arn:aws:lambda:us-west-2:663229565520:layer:sumologic-otel-lambda-java-x86_64-v2-15-0:1"


### PR DESCRIPTION
Preparations for releasing `java-v2.15.0`.

Note that it is expected for `markdown-link-check` to be failing here, because the release process documentation makes you update links that only become live later in the process...

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.