### PR TITLE
fix: add missing required dependency

### DIFF
--- a/nodejs/packages/layer/install-externals.sh
+++ b/nodejs/packages/layer/install-externals.sh
@@ -5,7 +5,7 @@ set -euf -o pipefail
 rm -rf ./build/workspace/node_modules
 
 # Space separated list of external NPM packages
-EXTERNAL_PACKAGES=( "import-in-the-middle" )
+EXTERNAL_PACKAGES=( "import-in-the-middle" "require-in-the-middle" )
 
 for EXTERNAL_PACKAGE in "${EXTERNAL_PACKAGES[@]}"
 do


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR adds a missing required dependency used by upstream in `install-externals.sh` 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
